### PR TITLE
pkg_resources: remove pkg_resources from zuul_lint

### DIFF
--- a/zuul_lint/__main__.py
+++ b/zuul_lint/__main__.py
@@ -3,11 +3,11 @@
 A linter for Zuul configuration files.
 """
 import argparse
+import importlib.metadata
 import json
 import pathlib
 import sys
 
-import pkg_resources
 import yaml
 from jsonschema import Draft7Validator
 
@@ -87,7 +87,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version=pkg_resources.get_distribution("zuul_lint").version,
+        version=importlib.metadata.version("zuul-lint"),
     )
     parser.add_argument("file", nargs="+", help="file(s) to lint")
     args = parser.parse_args()


### PR DESCRIPTION
pkg_resources is deprecated and will be removed in the future.  This change removes the dependency on pkg_resources from zuul_lint and replaces it with a simple importlib import.

Issue: none