### PR TITLE
feat: bump ruff to version 0.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -19,7 +19,7 @@ repos:
         args: ['--unsafe']
         files: .*\.(yaml|yml)$
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-required-version = "0.0.292"
 ignore = [
   "D211", # No blank lines allowed after function docstring
   "D213", # Multi-line docstring summary should start at the second line


### PR DESCRIPTION
Remove ruff `required-version` from pyproject.toml and bump to version 0.1.6 in pre-commit config

Issue: none