### PR TITLE
schema: Fix typo in gerrit-require-entry model

### DIFF
--- a/tests/zuul_data/pipelines.yaml
+++ b/tests/zuul_data/pipelines.yaml
@@ -35,6 +35,8 @@
         current-patchset: true
         approval:
           - Workflow: 1
+          - Verified: 1
+            username: foobar
     trigger:
       gerrit:
         - event: comment-added

--- a/zuullint/zuul-schema.json
+++ b/zuullint/zuul-schema.json
@@ -1758,7 +1758,7 @@
                                 }
                             },
                             "patternProperties": {
-                                "^(?!(username4|email$|older-than$|newer-than$).*)": {
+                                "^(?!(username$|email$|older-than$|newer-than$).*)": {
                                     "title": "pipeline.require.&lt;gerrit source&gt;.approval.&lt;review category&gt;",
                                     "allOf": [
                                         {


### PR DESCRIPTION
Fixed a typo in the "patternProperties" regex of the "approval" property of gerrit require sources. This typo caused the regex to match the "username" property as well.

Issue: None