### PR TITLE
schema: Add pipeline Timer trigger

### DIFF
--- a/tests/zuul_data/pipelines.yaml
+++ b/tests/zuul_data/pipelines.yaml
@@ -52,3 +52,13 @@
     failure:
       gerrit:
         Verified: -2
+
+- pipeline:
+    name: periodic-nightly
+    description: |
+      This pipeline is executed every hour from 1-4 AM on week days.
+    manager: independent
+    post-review: true
+    trigger:
+      timer:
+        - time: 0 1-4 * * 0-4

--- a/zuulcilint/zuul-schema.json
+++ b/zuulcilint/zuul-schema.json
@@ -773,7 +773,8 @@
                             "oneOf": [
                                 { "$ref": "#/definitions/github-trigger" },
                                 { "$ref": "#/definitions/gerrit-trigger" },
-                                { "$ref": "#/definitions/zuul-trigger" }
+                                { "$ref": "#/definitions/zuul-trigger" },
+                                { "$ref": "#/definitions/timer-trigger" }
                             ]
                         }
                     }
@@ -1464,6 +1465,22 @@
                         "type": "string",
                         "title": "pipeline.trigger.&lt;zuul source&gt;.pipeline",
                         "description": "Only available for parent-change-enqueued events. This is the name of the pipeline in which the parent change was enqueued."
+                    }
+                }
+            }
+        },
+        "timer-trigger": {
+            "title": "pipeline.trigger.&lt;timer&gt;",
+            "items": {
+                "type": "object",
+                "required": ["time"],
+                "properties": {
+                    "time": {
+                        "type": "string",
+                        "format": "regex",
+                        "pattern": "(((([0-5]?[0-9])(-[0-5]?[0-9])?)|\\*)([,/](([0-5]?[0-9])(-[0-5]?[0-9])?))*) ((((2[0-3]|(0|1)[0-9]|[0-9])(-(2[0-3]|(0|1)[0-9]|[0-9]))?)|\\*)([,/]((2[0-3]|(0|1)[0-9]|[0-9])(-(2[0-3]|(0|1)[0-9]|[0-9]))?))*) ((((3[01]|[12][0-9]|[1-9])(-(3[01]|[12][0-9]|[1-9]))?)|\\*))([,/]((3[01]|[12][0-9]|[1-9])(-(3[01]|[12][0-9]|[1-9]))?))* (((1[0-2]|[1-9])(-(1[0-2]|[1-9]))?)|\\*)(([,/]((1[0-2]|[1-9])(-(1[0-2]|[1-9]))?))*) ((([0-6])(-([0-6]))?|\\*)([,/]([0-6])(-([0-6]))?)*)( (([0-5]?[0-9])|\\*))?( ([0-9])+)?",
+                        "title": "pipeline.trigger.&lt;timere&gt;.time",
+                        "description": "The time specification in cron syntax. Only the 5 part syntax is supported, not the symbolic names. Example: 0 0 * * * runs at midnight.\nAn optional 6th part specifies seconds. The optional 7th part specifies a jitter in seconds. This delays the trigger randomly, limited by the specified value. Example 0 0 * * * * 60 runs at midnight or randomly up to 60 seconds later. The jitter is applied individually to each project-branch combination. While the jitter is initialized to a random value, the same value will often be used for a given project-branch combination (in other words, it is not guaranteed to vary from one run of the timer trigger to the next)."
                     }
                 }
             }


### PR DESCRIPTION
Updated the json schema to support Timer triggers in pipelines. The time property uses a custom regex for cron syntax where the optional 6th part specifies seconds and the optional 7th part specifies a jitter in seconds. All done according to the Zuul documentation.

Zuul docs: https://zuul-ci.org/docs/zuul/latest/drivers/timer.html
Regex tests: https://regexr.com/7p7ot

Issue: None