### PR TITLE
refactor get_all_zuul_yaml_files() function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "poetry.core.masonry.api"
 
 # Configurations for black
 [tool.black]
-line-length = 88
+line-length = 100
 target-version = ["py38"]
 include = '\.pyi?$'
 exclude = '''
@@ -72,7 +72,7 @@ ignore = [
 select = ["ALL"]
 target-version = "py310"
 # Same as Black.
-line-length = 88
+line-length = 100
 
 [tool.ruff.per-file-ignores]
 "tests/**/*.py" = ["S101"] # Use of assert detected.

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -44,8 +44,8 @@ def test_check_job_playbook_paths():
     ]
 
 
-def test_check_repeated_jobs():
-    """Test that check_repeated_jobs() returns a set of repeated jobs."""
+def test_check_duplicated_jobs():
+    """Test that duplicated_jobs() returns a set of repeated jobs."""
     jobs = [
         [
             {"job": {"name": "test-job"}},
@@ -58,4 +58,4 @@ def test_check_repeated_jobs():
 
     jobs = [[job.get("job").get("name") for job in sublist] for sublist in jobs]
 
-    assert zuulcilint_checker.check_repeated_jobs(jobs) == {("test-job")}
+    assert zuulcilint_checker.check_duplicated_jobs(jobs) == {("test-job")}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_get_zuul_yaml_files_find():
     tmp_path = setup_tmp_list_of_files()
     default_len = 2
     zuul_yaml_files = [
-        file.name for file in zuulcilint_utils.get_zuul_yaml_files(tmp_path)
+        f.name for f in zuulcilint_utils.get_zuul_yaml_files(tmp_path)["good_yaml"]
     ]
     assert len(zuul_yaml_files) == default_len
     assert "file0.yaml" in zuul_yaml_files
@@ -98,12 +98,14 @@ def test_get_zuul_yaml_files_skip():
     tmp_path = tmp_path / "file2.yaml"
     with pathlib.Path.open(tmp_path, "w", encoding="utf-8") as f:
         f.write("hello")
-    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)) == 1
+    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)["good_yaml"]) == 1
+    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)["bad_yaml"]) == 0
 
     tmp_path = tmp_path.parent / "file3.yml"
     with pathlib.Path.open(tmp_path, "w", encoding="utf-8") as f:
         f.write("hello")
-    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)) == 0
+    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)["good_yaml"]) == 0
+    assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)["bad_yaml"]) == 1
 
 
 def test_get_jobs_from_zuul_yaml():

--- a/zuulcilint/checker.py
+++ b/zuulcilint/checker.py
@@ -32,7 +32,7 @@ def check_job_playbook_paths(
     return invalid_paths
 
 
-def check_repeated_jobs(
+def check_duplicated_jobs(
     jobs: list[list[dict[str, str] | None]],
 ) -> set[dict[str, str] | None]:
     """Check that all jobs are unique in different Zuul YAML files.
@@ -43,18 +43,18 @@ def check_repeated_jobs(
 
     Returns:
     -------
-        A set of repeated jobs.
+        A set of duplicated jobs.
     """
     seen_items = set()
-    repeated_items = set()
+    duplicated_items = set()
     unique_items = set()
 
     for sublist in jobs:
         sublist_set = set(sublist)
         for job in sublist_set:
             if job in seen_items:
-                repeated_items.add(job)
+                duplicated_items.add(job)
             seen_items.add(job)
         unique_items.update(sublist_set)
 
-    return repeated_items
+    return duplicated_items

--- a/zuulcilint/utils.py
+++ b/zuulcilint/utils.py
@@ -57,8 +57,8 @@ def get_zuul_yaml_files(path: pathlib.Path) -> dict[str, list[pathlib.Path]]:
                 pass
     elif(path.is_dir()):
         for p in path.iterdir():
-            for yaml_file, yaml_file_path in get_zuul_yaml_files(p).items():
-                zuul_yaml_files[yaml_file].extend(yaml_file_path)
+            for file_type, yaml_file_path in get_zuul_yaml_files(p).items():
+                zuul_yaml_files[file_type].extend(yaml_file_path)
 
     else:
         print(f"Skipping {path}")

--- a/zuulcilint/utils.py
+++ b/zuulcilint/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import pathlib
 import sys
+from collections import defaultdict
 
 import yaml
 
@@ -31,8 +32,8 @@ def get_zuul_schema(schema_file: str) -> dict:
         sys.exit(1)
 
 
-def get_zuul_yaml_files(path: pathlib.Path) -> list[pathlib.Path]:
-    """Retrieve a list of Zuul YAML files from the specified path.
+def get_zuul_yaml_files(path: pathlib.Path) -> dict[str, list[pathlib.Path]]:
+    """Retrieve a dictionary of Zuul YAML/YML files from the specified path.
 
     Args:
     ----
@@ -40,16 +41,28 @@ def get_zuul_yaml_files(path: pathlib.Path) -> list[pathlib.Path]:
 
     Returns:
     -------
-        List[Path]: A list of Path objects representing the Zuul YAML files found.
+        dict[str, List[Path]]: A dictionary containing the keys 'good_yaml'(.yaml) and
+        'bad_yaml'(.yml), where values are lists containing the Path objects for each
+        of the file extensions found.
     """
-    zuul_yaml_files = []
-    if path.is_file() and path.suffix == ".yaml":
-        zuul_yaml_files.append(path)
-    elif path.is_dir():
+    zuul_yaml_files = defaultdict(list)
+
+    if(path.is_file()):
+        match path.suffix:
+            case ".yaml":
+                zuul_yaml_files["good_yaml"].append(path)
+            case ".yml":
+                zuul_yaml_files["bad_yaml"].append(path)
+            case _:
+                pass
+    elif(path.is_dir()):
         for p in path.iterdir():
-            zuul_yaml_files.extend(get_zuul_yaml_files(p))
+            for yaml_file, yaml_file_path in get_zuul_yaml_files(p).items():
+                zuul_yaml_files[yaml_file].extend(yaml_file_path)
+
     else:
         print(f"Skipping {path}")
+
     return zuul_yaml_files
 
 


### PR DESCRIPTION
get_all_zuul_yaml_files() now returns a dictionary where the keys contain the extensions of files found:
- extension: .yaml ---> key: "good_yaml"
- extension: .yml ---> key: "bad_yaml" for each key(file extension) there is a list of paths where files with the respective extension can be found. test_utils.py was modified to account for the changes mentioned above.

ruff line-length limit was increased from 88 to 100.