### PR TITLE
Handle warnings with argparse

### DIFF
--- a/tests/zuul_data/jobs2.yaml
+++ b/tests/zuul_data/jobs2.yaml
@@ -1,0 +1,8 @@
+---
+- job:
+    name: base
+    parent: null
+    nodeset:
+      nodes:
+        - name: ubuntu-jammy
+          label: ubuntu-jammy

--- a/tests/zuul_data_invalid/zuul-config-invalid.yml
+++ b/tests/zuul_data_invalid/zuul-config-invalid.yml
@@ -1,0 +1,6 @@
+---
+- jobs:  # must fail as correct is 'job'
+    name: foo
+- job:
+    roles:
+      - install-docker  # should be "zuul: install-docker"

--- a/zuulcilint/__main__.py
+++ b/zuulcilint/__main__.py
@@ -101,38 +101,75 @@ def get_all_jobs(zuul_yaml_files: list[pathlib.Path]) -> list[list[str]]:
     return all_jobs
 
 
-def print_warnings(bad_yml_files: list[str], duplicated_jobs: set[str]) -> None:
+def print_warnings(
+    bad_yml_files: list[str],
+    duplicated_jobs: set[str],
+    severity: str="warning",
+) -> None:
     """Print warnings."""
-    nr_warnings = len(bad_yml_files) + len(duplicated_jobs)
-    print(f"Total warnings: {nr_warnings}")
+    n_bad = len(bad_yml_files)
+    n_dup = len(duplicated_jobs)
+
+    if n_bad == 0 and n_dup == 0:
+        return
+
+    if severity == "warning":
+        zuul_utils.print_bold("Warnings", severity)
+        print(f"Total {severity}s: {n_bad + n_dup}")
+
     if bad_yml_files:
+        zuul_utils.print_bold(f"File extension {severity}s:", severity)
         zuul_utils.print_bold(
-            f"Found {len(bad_yml_files)} files with 'yml' extension",
+            f"Found {n_bad} files with 'yml' extension",
             None,
         )
         for file_path in bad_yml_files:
             print(f"  {file_path}")
     if duplicated_jobs:
-        zuul_utils.print_bold(f"Found {len(duplicated_jobs)} duplicate jobs", None)
+        zuul_utils.print_bold(f"Duplicate job {severity}s:", severity)
+        zuul_utils.print_bold(f"Found {n_dup} duplicate jobs", None)
         for job in duplicated_jobs:
             print(f"  {job}")
 
-
 def print_results(
-    errors: dict,
-    invalid_playbook_paths: list[str],
+    results: dict,
+    bad_yaml_files: list[pathlib.Path],
+    duplicated_jobs: set[str],
+    warnings_as_errors,
+    ignore_warnings,
 ) -> None:
     """Print the linting results."""
-    nr_errors = errors["yaml"] + errors["playbook_paths"]
-    print(f"Total errors: {nr_errors}")
-    print(f"YAML errors: {errors['yaml']}")
-    print(f"Playbook path errors: {errors['playbook_paths']}")
-    if invalid_playbook_paths:
-        print("Invalid playbook paths:")
-        for path in invalid_playbook_paths:
-            print(f"  {path}")
-    sys.exit(1)
+    total_yaml_errors = results["errors"]["yaml"]
+    total_playbook_path_errors = results["errors"]["playbook_paths"]
+    total_warnings = results["warnings"]["file_extension"] + results["warnings"]["duplicated_jobs"]
+    total_errs = total_yaml_errors + total_playbook_path_errors
+    extra_msg = ""
 
+    # --warnings-as-errors flag has higher precedence than --ignore-warnings
+    if warnings_as_errors:
+        total_errs += total_warnings
+        if bad_yaml_files:
+            extra_msg += f"\n  File extension errors: {results['warnings']['file_extension']}"
+        if duplicated_jobs:
+            extra_msg += f"\n  Duplicated jobs errors: {results['warnings']['duplicated_jobs']}"
+        print_warnings(bad_yaml_files, duplicated_jobs, severity="error")
+    elif not ignore_warnings:
+        print_warnings(bad_yaml_files, duplicated_jobs)
+
+    if total_errs == 0:
+        zuul_utils.print_bold("Passed", "success")
+        sys.exit(0)
+
+    zuul_utils.print_bold("Failed", "error")
+    err_msg = f"  Total errors: {total_errs}\n"
+
+    if total_yaml_errors:
+        err_msg += f"  YAML validation errors: {total_yaml_errors}"
+    if total_playbook_path_errors:
+        err_msg += f"\n  Playbook path errors: {total_playbook_path_errors}"
+
+    print(f"{err_msg + extra_msg}")
+    sys.exit(1)
 
 def main():
     """Parse command-line arguments and run the Zuul linter on the specified file(s).
@@ -161,13 +198,21 @@ def main():
         default=pathlib.Path(__file__).parent / "zuul-schema.json",
         type=pathlib.Path,
     )
+    parser.add_argument("--ignore-warnings",
+                        "-i",
+                        help="ignore warnings",
+                        action="store_true",
+    )
+    parser.add_argument("--warnings-as-errors",
+                        help="handle warnings as errors",
+                        action="store_true",
+    )
 
     args = parser.parse_args()
     schema = zuul_utils.get_zuul_schema(schema_file=args.schema)
     all_zuul_yaml_files = get_all_zuul_yaml_files(args.file)
     zuul_good_yaml = all_zuul_yaml_files["good_yaml"]
     zuul_bad_yaml = all_zuul_yaml_files["bad_yaml"]
-    invalid_playbook_paths = []
 
     # Initialize results dictionary
     results = {
@@ -177,15 +222,19 @@ def main():
 
     # Lint all Zuul YAML files
     results["errors"]["yaml"] = lint_all_yaml_files(zuul_good_yaml, schema)
-    results["warnings"]["file_extension"] = len(zuul_good_yaml)
+    results["warnings"]["file_extension"] = len(zuul_bad_yaml)
 
     # Check playbook paths if specified
     if args.check_playbook_paths:
         zuul_utils.print_bold("Checking playbook paths", "info")
         invalid_playbook_paths = lint_playbook_paths(zuul_good_yaml)
-        results["errors"]["playbook_paths"] = len(invalid_playbook_paths)
-        for path in invalid_playbook_paths:
-            print(f"  {path}")
+        if(invalid_playbook_paths):
+            results["errors"]["playbook_paths"] = len(invalid_playbook_paths)
+            zuul_utils.print_bold("  Invalid playbook paths:", "error")
+            for path in invalid_playbook_paths:
+                print(f"\t{path}")
+        else:
+            print("  No invalid playbook paths")
 
     # Check duplicated jobs
     zuul_utils.print_bold("Checking for duplicate jobs", "info")
@@ -197,22 +246,14 @@ def main():
         print("  No duplicate jobs found")
     results["warnings"]["duplicated_jobs"] = len(duplicated_jobs)
 
-    # Print warnings
-    zuul_utils.print_bold("Warnings", "warning")
-    print_warnings(zuul_bad_yaml, duplicated_jobs)
-
     # Print results
-    if results["errors"]["yaml"] or results["errors"]["playbook_paths"]:
-        zuul_utils.print_bold("Failed", "error")
-        print_results(
-            results["errors"],
-            invalid_playbook_paths,
-        )
-
-    # Print success message
-    zuul_utils.print_bold("Passed", "success")
-    sys.exit(0)
-
+    print_results(
+        results,
+        zuul_bad_yaml,
+        duplicated_jobs,
+        args.warnings_as_errors,
+        args.ignore_warnings,
+    )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add 2 new args:
    -i, --ignore-warnings
    --warnings-as-errors
if both args are passed simultaneous, --warnings-as-errors will have higher precedence.