### PR TITLE
Run tox with multiple version of python3

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,11 +13,17 @@ env:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install Poetry
         run: pip install poetry
       - name: Install dependencies

--- a/zuulcilint/utils.py
+++ b/zuulcilint/utils.py
@@ -48,13 +48,10 @@ def get_zuul_yaml_files(path: pathlib.Path) -> dict[str, list[pathlib.Path]]:
     zuul_yaml_files = defaultdict(list)
 
     if(path.is_file()):
-        match path.suffix:
-            case ".yaml":
-                zuul_yaml_files["good_yaml"].append(path)
-            case ".yml":
-                zuul_yaml_files["bad_yaml"].append(path)
-            case _:
-                pass
+        if path.suffix == ".yaml":
+            zuul_yaml_files["good_yaml"].append(path)
+        elif path.suffix == ".yml":
+            zuul_yaml_files["bad_yaml"].append(path)
     elif(path.is_dir()):
         for p in path.iterdir():
             for file_type, yaml_file_path in get_zuul_yaml_files(p).items():


### PR DESCRIPTION
github action was only using python3.10 when running tox,
but the tool can be run since python3.8.
This will add tox run for python 3.8 and 3.9.

Also adapt the code to be compatible with python older then 3.10