### PR TITLE
generic-zuul-obj: get zuul object from yaml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -643,13 +643,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.12.0"
+version = "4.12.1"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.12.0-py3-none-any.whl", hash = "sha256:c94bf5852ba41f3d9f1e3470ccf3390e0b7bdc938095be3cd96dce25ab5062a0"},
-    {file = "tox-4.12.0.tar.gz", hash = "sha256:76adc53a3baff7bde80d6ad7f63235735cfc5bc42e8cb6fccfbf62cb5ffd4d92"},
+    {file = "tox-4.12.1-py3-none-any.whl", hash = "sha256:c07ea797880a44f3c4f200ad88ad92b446b83079d4ccef89585df64cc574375c"},
+    {file = "tox-4.12.1.tar.gz", hash = "sha256:61aafbeff1bd8a5af84e54ef6e8402f53c6a6066d0782336171ddfbf5362122e"},
 ]
 
 [package.dependencies]
@@ -706,4 +706,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8, <4.0"
-content-hash = "a2158b30f54ce8bd0d8d7ba1fa70f5f4f166569d46fe39abd5f042fe511f6e79"
+content-hash = "a7eb18ffae012d5d8806970538042e79f35c3c925524d87beaa653dd04c0ea72"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zuulcilint"
-version = "0.2.4"
+version = "0.2.5"
 description = "Zuul CI linter"
 authors = ["Pedro Baptista <pedro.miguel.baptista@gmail.com>"]
 license = "MIT"
@@ -22,7 +22,7 @@ six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"
-pytest = "^7.4.3"
+pytest = "^7.4.4"
 tox = "^4.12.0"
 pytest-cov = "^4.1.0"
 ruff = "^0.1.13"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -9,6 +9,7 @@ import tempfile
 
 import zuulcilint.checker as zuulcilint_checker
 import zuulcilint.utils as zuulcilint_utils
+from zuulcilint.utils import ZuulObject
 
 
 def setup_zuul_job_yaml():
@@ -35,9 +36,9 @@ def setup_zuul_job_yaml():
 def test_check_job_playbook_paths():
     """Test that check_job_playbook_paths() returns a list of invalid paths."""
     tmp_path = setup_zuul_job_yaml()
-    jobs = zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")
+    jobs = zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "job.yaml")
 
-    assert zuulcilint_checker.check_job_playbook_paths(jobs[0].get("job")) == [
+    assert zuulcilint_checker.check_job_playbook_paths(jobs[0].get(ZuulObject.JOB.value)) == [
         "playbooks/pre-run.yaml",
         "playbooks/run.yaml",
         "playbooks/post-run.yaml",
@@ -56,6 +57,6 @@ def test_check_duplicated_jobs():
         ],
     ]
 
-    jobs = [[job.get("job").get("name") for job in sublist] for sublist in jobs]
+    jobs = [[job.get(ZuulObject.JOB.value).get("name") for job in sublist] for sublist in jobs]
 
     assert zuulcilint_checker.check_duplicated_jobs(jobs) == {("test-job")}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import tempfile
 import pytest
 
 import zuulcilint.utils as zuulcilint_utils
+from zuulcilint.utils import ZuulObject
 
 
 def setup_tmp_list_of_files():
@@ -24,7 +25,7 @@ def setup_tmp_list_of_files():
     return tmp_path
 
 
-def setup_zuul_job_yaml():
+def setup_zuul_obj_yaml(obj_type: ZuulObject):
     """Create a temporary directory with a list of files.
 
     Returns
@@ -32,9 +33,11 @@ def setup_zuul_job_yaml():
         A Path object representing the temporary directory.
     """
     tmp_path = pathlib.Path(tempfile.mkdtemp())
-    with pathlib.Path.open(tmp_path / "job.yaml", "w", encoding="utf-8") as f:
+    with pathlib.Path.open(tmp_path / f"{obj_type.value}.yaml", "w", encoding="utf-8") as f:
         f.write(
-            """
+            f"""
+            - {obj_type.value}:
+                name: test-{obj_type.value}
             - job:
                 name: test-job
                 pre-run: playbooks/pre-run.yaml
@@ -76,9 +79,7 @@ def test_get_zuul_yaml_files_find():
     """Test that get_zuul_yaml_files() finds files."""
     tmp_path = setup_tmp_list_of_files()
     default_len = 2
-    zuul_yaml_files = [
-        f.name for f in zuulcilint_utils.get_zuul_yaml_files(tmp_path)["good_yaml"]
-    ]
+    zuul_yaml_files = [f.name for f in zuulcilint_utils.get_zuul_yaml_files(tmp_path)["good_yaml"]]
     assert len(zuul_yaml_files) == default_len
     assert "file0.yaml" in zuul_yaml_files
     assert "file1.yaml" in zuul_yaml_files
@@ -108,50 +109,145 @@ def test_get_zuul_yaml_files_skip():
     assert len(zuulcilint_utils.get_zuul_yaml_files(tmp_path)["bad_yaml"]) == 1
 
 
-def test_get_jobs_from_zuul_yaml():
-    """Test that get_jobs_from_zuul_yaml() returns a list of jobs."""
-    tmp_path = setup_zuul_job_yaml()
-    jobs = zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")
-    assert len(jobs) == 1
+def test_get_zuul_object_from_yaml_job():
+    """Test that get_zuul_object_from_yaml() returns a list of jobs."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
+    jobs = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.JOB,
+        tmp_path / f"{ZuulObject.JOB.value}.yaml",
+    )
+    jobs_len = 2
+    assert len(jobs) == jobs_len
     assert jobs[0]["job"]["name"] == "test-job"
 
 
-def test_get_jobs_from_zuul_yaml_invalid_yaml():
+def test_get_zuul_object_from_yaml_nodeset():
+    """Test that get_zuul_object_from_yaml() returns a list of nodesets."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.NODESET)
+    nodesets = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.NODESET,
+        tmp_path / f"{ZuulObject.NODESET.value}.yaml",
+    )
+    assert len(nodesets) == 1
+    assert nodesets[0]["nodeset"]["name"] == "test-nodeset"
+
+
+def test_get_zuul_object_from_yaml_pipeline():
+    """Test that get_zuul_object_from_yaml() returns a list of pipelines."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.PIPELINE)
+    pipelines = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.PIPELINE,
+        tmp_path / f"{ZuulObject.PIPELINE.value}.yaml",
+    )
+    assert len(pipelines) == 1
+    assert pipelines[0]["pipeline"]["name"] == "test-pipeline"
+
+
+def test_get_zuul_object_from_yaml_pragma():
+    """Test that get_zuul_object_from_yaml() returns a list of pragmas."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.PRAGMA)
+    pragmas = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.PRAGMA,
+        tmp_path / f"{ZuulObject.PRAGMA.value}.yaml",
+    )
+    assert len(pragmas) == 1
+    assert pragmas[0]["pragma"]["name"] == "test-pragma"
+
+
+def test_get_zuul_object_from_yaml_project():
+    """Test that get_zuul_object_from_yaml() returns a list of projects."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.PROJECT)
+    projects = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.PROJECT,
+        tmp_path / f"{ZuulObject.PROJECT.value}.yaml",
+    )
+    assert len(projects) == 1
+    assert projects[0]["project"]["name"] == "test-project"
+
+
+def test_get_zuul_object_from_yaml_queue():
+    """Test that get_zuul_object_from_yaml() returns a list of queues."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.QUEUE)
+    queues = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.QUEUE,
+        tmp_path / f"{ZuulObject.QUEUE.value}.yaml",
+    )
+    assert len(queues) == 1
+    assert queues[0]["queue"]["name"] == "test-queue"
+
+
+def test_get_zuul_object_from_yaml_secret():
+    """Test that get_zuul_object_from_yaml() returns a list of secrets."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.SECRET)
+    secrets = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.SECRET,
+        tmp_path / f"{ZuulObject.SECRET.value}.yaml",
+    )
+    assert len(secrets) == 1
+    assert secrets[0]["secret"]["name"] == "test-secret"
+
+
+def test_get_zuul_object_from_yaml_semaphore():
+    """Test that get_zuul_object_from_yaml() returns a list of semaphores."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.SEMAPHORE)
+    semaphores = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.SEMAPHORE,
+        tmp_path / f"{ZuulObject.SEMAPHORE.value}.yaml",
+    )
+    assert len(semaphores) == 1
+    assert semaphores[0]["semaphore"]["name"] == "test-semaphore"
+
+
+def test_get_zuul_object_from_yaml_template():
+    """Test that get_zuul_object_from_yaml() returns a list of templates."""
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.TEMPLATE)
+    templates = zuulcilint_utils.get_zuul_object_from_yaml(
+        ZuulObject.TEMPLATE,
+        tmp_path / f"{ZuulObject.TEMPLATE.value}.yaml",
+    )
+    assert len(templates) == 1
+    assert templates[0]["project-template"]["name"] == "test-project-template"
+
+
+def test_get_zuul_object_from_yaml_invalid_yaml():
     """Test exits when the YAML is invalid."""
-    tmp_path = setup_zuul_job_yaml()
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
     with pathlib.Path.open(tmp_path / "job.yaml", "w", encoding="utf-8") as f:
         f.write("{- foo = bar}")
     with pytest.raises(SystemExit):
-        zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")
+        zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "job.yaml")
 
 
-def test_get_jobs_from_zuul_yaml_no_jobs():
+def test_get_zuul_object_from_yaml_no_jobs():
     """Test return an empty list when no jobs are found."""
-    tmp_path = setup_zuul_job_yaml()
-    with pathlib.Path.open(tmp_path / "job.yaml", "w", encoding="utf-8") as f:
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
+    with pathlib.Path.open(tmp_path / "no-job.yaml", "w", encoding="utf-8") as f:
         f.write(
             """
             - pipeline:
                 name: test-pipeline
             """,
         )
-    assert len(zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")) == 0
+    assert (
+        len(zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "no-job.yaml"))
+        == 0
+    )
 
 
-def test_get_jobs_from_zuul_yaml_no_file():
+def test_get_zuul_object_from_yaml_no_file():
     """Test return an empty list when no file is found."""
-    tmp_path = setup_zuul_job_yaml()
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
     try:
-        zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "invalid_file")
+        zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "invalid_file")
     except SystemExit:
         pytest.raises(FileNotFoundError)
 
 
 def test_get_playbook_paths_from_job():
     """Test that get_playbook_paths_from_job() returns a list of playbook paths."""
-    tmp_path = setup_zuul_job_yaml()
-    jobs = zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")
-    playbook_paths = zuulcilint_utils.get_playbook_paths_from_job(jobs[0].get("job"))
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
+    jobs = zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "job.yaml")
+    playbook_paths = zuulcilint_utils.get_playbook_paths_from_job(jobs[1].get("job"))
     size = 3
     assert len(playbook_paths) == size
     assert playbook_paths[0] == "playbooks/pre-run.yaml"
@@ -161,7 +257,7 @@ def test_get_playbook_paths_from_job():
 
 def test_get_playbook_paths_from_job_no_playbook_paths():
     """Test return an empty list when no playbook paths are found."""
-    tmp_path = setup_zuul_job_yaml()
+    tmp_path = setup_zuul_obj_yaml(ZuulObject.JOB)
     with pathlib.Path.open(tmp_path / "job.yaml", "w", encoding="utf-8") as f:
         f.write(
             """
@@ -169,7 +265,7 @@ def test_get_playbook_paths_from_job_no_playbook_paths():
                 name: test-job
             """,
         )
-    jobs = zuulcilint_utils.get_jobs_from_zuul_yaml(tmp_path / "job.yaml")
+    jobs = zuulcilint_utils.get_zuul_object_from_yaml(ZuulObject.JOB, tmp_path / "job.yaml")
     playbook_paths = zuulcilint_utils.get_playbook_paths_from_job(jobs[0].get("job"))
     assert len(playbook_paths) == 0
 

--- a/tests/test_zuulcilint.py
+++ b/tests/test_zuulcilint.py
@@ -18,7 +18,7 @@ def test_invalid():
     try:
         subprocess.check_call(
             [
-                "python",
+                "python3",
                 "-m",
                 "zuulcilint",
                 "tests/zuul_data_invalid/zuul-config-invalid.yaml",
@@ -40,7 +40,7 @@ def test_valid():
     """
     try:
         subprocess.call(
-            ["python", "zuulcilint", "-m", "tests/zuul_data"],
+            ["python3", "zuulcilint", "-m", "tests/zuul_data"],
         )
     except subprocess.CalledProcessError as e:
         pytest.fail(e)

--- a/zuulcilint/__main__.py
+++ b/zuulcilint/__main__.py
@@ -14,7 +14,7 @@ from jsonschema import Draft201909Validator
 
 import zuulcilint.checker as zuul_checker
 import zuulcilint.utils as zuul_utils
-from zuulcilint.utils import MsgSeverity
+from zuulcilint.utils import MsgSeverity, ZuulObject
 
 # Register custom yaml constructor for "encrypted/pkcs1-oaep"
 yaml.SafeLoader.add_constructor(
@@ -75,10 +75,10 @@ def lint_playbook_paths(zuul_yaml_files: list[pathlib.Path]) -> list[str]:
     """Lint playbook paths in all Zuul YAML files."""
     invalid_paths = []
     for file_path in zuul_yaml_files:
-        jobs = zuul_utils.get_jobs_from_zuul_yaml(file_path)
+        jobs = zuul_utils.get_zuul_object_from_yaml(ZuulObject.JOB, file_path)
         for job in jobs:
             invalid_paths.extend(
-                zuul_checker.check_job_playbook_paths(job.get("job", {})),
+                zuul_checker.check_job_playbook_paths(job.get(ZuulObject.JOB.value, {})),
             )
     return invalid_paths
 
@@ -97,8 +97,8 @@ def get_all_jobs(zuul_yaml_files: list[pathlib.Path]) -> list[list[str]]:
     """Get all jobs from Zuul YAML files."""
     all_jobs = []
     for file_path in zuul_yaml_files:
-        jobs = zuul_utils.get_jobs_from_zuul_yaml(file_path)
-        all_jobs.append([job.get("job", {}).get("name") for job in jobs])
+        jobs = zuul_utils.get_zuul_object_from_yaml(ZuulObject.JOB, file_path)
+        all_jobs.append([job.get(ZuulObject.JOB.value, {}).get("name") for job in jobs])
     return all_jobs
 
 

--- a/zuulcilint/utils.py
+++ b/zuulcilint/utils.py
@@ -33,6 +33,21 @@ class MsgTypeColor(Enum):
     RESET = "\33[0m"
 
 
+class ZuulObject(Enum):
+
+    """Enum representing Zuul objects."""
+
+    JOB = "job"
+    NODESET = "nodeset"
+    PIPELINE = "pipeline"
+    PRAGMA = "pragma"
+    PROJECT = "project"
+    QUEUE = "queue"
+    SECRET = "secret" # noqa: S105
+    SEMAPHORE = "semaphore"
+    TEMPLATE = "project-template"
+
+
 def get_zuul_schema(schema_file: str) -> dict:
     """Load the Zuul schema from a JSON file.
 
@@ -86,20 +101,23 @@ def get_zuul_yaml_files(path: pathlib.Path) -> dict[str, list[pathlib.Path]]:
     return zuul_yaml_files
 
 
-def get_jobs_from_zuul_yaml(zuul_yaml_file: str) -> list[dict[str, str] | None]:
-    """Retrieve a list of Zuul jobs from the specified YAML file.
+def get_zuul_object_from_yaml(
+    obj_type: ZuulObject, zuul_yaml_file: str,
+) -> list[dict[str, str] | None]:
+    """Retrieve a list of Zuul objects from the specified YAML file.
 
     Args:
     ----
-        zuul_yaml_file: The path to the YAML file to search for Zuul jobs.
+        obj_type: The type of object to search for.
+        zuul_yaml_file: The path to the YAML file to search for Zuul objects.
 
     Returns:
     -------
-        A list of dictionaries representing the Zuul jobs found.
+        A list of dictionaries representing the Zuul objects found.
     """
     try:
         with pathlib.Path.open(zuul_yaml_file, encoding="utf-8") as f:
-            return [job for job in yaml.safe_load(f) if job.get("job")]
+            return [obj for obj in yaml.safe_load(f) if obj.get(obj_type.value)]
     except FileNotFoundError:
         print(f"Zuul YAML file not found: {zuul_yaml_file}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Return zuul objects from yaml based on object type
Include Enum for each object
Tests for each object added

Issue: https://github.com/codesquadnest/zuulcilint/issues/20