### PR TITLE
schema: Fix type of reject.<source>.status

### DIFF
--- a/tests/zuul_data/pipelines.yaml
+++ b/tests/zuul_data/pipelines.yaml
@@ -90,3 +90,36 @@
             - foofoo
             - regex: barbar
               negate: false
+
+- pipeline:
+    name: test-rejects
+    manager: independent
+    trigger:
+      gerrit:
+        - event: comment-added
+          comment: foo
+          reject:
+            status: "zuul:check:success"
+        - event: comment-added
+          comment:
+            regex: bar
+          reject:
+            status:
+              - "zuul:check:success"
+
+      github:
+        - event: pull_request
+          comment: foo
+          reject:
+            status: "zuul:check:success"
+        - event: pull_request
+          comment:
+            regex: bar
+          reject:
+            status:
+              - "zuul:check:success"
+
+    reject:
+      github:
+        status:
+          - "zuul:check:success"

--- a/zuulcilint/zuul-schema.json
+++ b/zuulcilint/zuul-schema.json
@@ -2,7 +2,7 @@
     "title": "JSON/YAML schema for Zuul CI 11.0.1 configuration files",
     "description": "Used for quick validation of Zuul CI job configuration files.",
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "type": "array",
     "additionalProperties": false,
     "items": {
@@ -2109,7 +2109,8 @@
                     "description": "A boolean value (true or false) that indicates whether or not the change must be marked as a draft in GitHub in order to be rejected."
                 },
                 "status": {
-                    "type": "string",
+                    "type": ["string", "array"],
+                    "items": { "type": "string" },
                     "title": "pipeline.reject.&lt;github source&gt;.status",
                     "description": "A string value that corresponds with the status of the pull request. The syntax is user:status:value. This can also be a regular expression.\r\n\r\nZuul does not differentiate between a status reported via status API or via checks API (which is also how Github behaves in terms of branch protection and status checks). Thus, the status could be reported by a pipeline.<reporter>.<github source>.status or a pipeline.<reporter>.<github source>.check.\r\n\r\nWhen a status is reported via the status API, Github will add a [bot] to the name of the app that reported the status, resulting in something like user[bot]:status:value. For a status reported via the checks API, the app\u2019s slug will be used as is."
                 },
@@ -2189,7 +2190,8 @@
                     "description": "A boolean value (true or false) that indicates whether the change must be wip or not wip in order to be rejected."
                 },
                 "status": {
-                    "type": "boolean",
+                    "type": ["string", "array"],
+                    "items": { "type": "string" },
                     "title": "pipeline.reject.&lt;gerrit source&gt;.status",
                     "description": "A string value that corresponds with the status of the change reported by Gerrit."
                 }
@@ -2231,7 +2233,8 @@
                                     "description": "A boolean value (true or false) that indicates whether the change must be the current patchset in order to be rejected."
                                 },
                                 "status": {
-                                    "type": "string",
+                                    "type": ["string", "array"],
+                                    "items": { "type": "string" },
                                     "title": "pipeline.reject.&lt;ambiguous gerrit/github source&gt;.status",
                                     "description": "GitHub:\n\nA string value that corresponds with the status of the pull request. The syntax is user:status:value. This can also be a regular expression.\r\n\r\nZuul does not differentiate between a status reported via status API or via checks API (which is also how Github behaves in terms of branch protection and status checks). Thus, the status could be reported by a pipeline.<reporter>.<github source>.status or a pipeline.<reporter>.<github source>.check.\r\n\r\nWhen a status is reported via the status API, Github will add a [bot] to the name of the app that reported the status, resulting in something like user[bot]:status:value. For a status reported via the checks API, the app\u2019s slug will be used as is.\n\nGerrit:\n\nA string value that corresponds with the status of the change reported by Gerrit."
                                 }


### PR DESCRIPTION
Edited the relevant "status" properties to allow either a list of
strings or a single string.

Issue: #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new pipeline, `test-rejects`, allowing for specific rejection criteria based on user comments in both Gerrit and GitHub.
  
- **Improvements**
	- Updated the Zuul CI configuration schema to version 1.2.1, enabling multiple status values for rejection conditions, enhancing flexibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->