### PR TITLE
Add support to ansible version 11

### DIFF
--- a/zuulcilint/zuul-schema.json
+++ b/zuulcilint/zuul-schema.json
@@ -132,10 +132,10 @@
                 },
                 "ansible-version": {
                     "default": "9",
-                    "enum": ["9", 9],
+                    "enum": ["9", 9, "11", 11],
                     "title": "job.ansible-version",
                     "description": "The ansible version to use for all playbooks of the job.",
-                    "examples": ["https://zuul-ci.org/docs/zuul/11.2.0/config/job.html#attr-job.ansible-version"]
+                    "examples": ["https://zuul-ci.org/docs/zuul/13.0.0/config/job.html#attr-job.ansible-version"]
                 },
                 "attempts": {
                     "type": "integer",


### PR DESCRIPTION
Add ansible version 11 to schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Ansible version support in job configurations to include Ansible 11 alongside Ansible 9.

* **Documentation**
  * Updated example reference to point to the newer Zuul documentation (13.0.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->