### PR TITLE
zuulcilint: add YAML config file support with per-rule severity control

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,107 @@
+# zuulcilint Configuration File
+
+zuulcilint supports an optional YAML configuration file for controlling linting behaviour without CLI flags.
+
+## Resolution Order
+
+Config sources are **mutually exclusive** — only the highest-priority source found is used. Resolution order (later/higher overrides earlier/lower):
+
+1. `~/.zuulcilint.yaml` — user home (lowest priority)
+2. `<repo-root>/.zuulcilint.yaml` — repository-level config (committed alongside your Zuul files)
+3. `--config <path>` — explicit path passed on the CLI (highest priority, overrides both above)
+
+Only one config file is ever loaded. If `--config` is given, home and repo-level files are ignored. If a repo-level file exists, the home-level file is ignored.
+
+## Config Format
+
+Two formats are accepted:
+
+**Flat (recommended):**
+```yaml
+version: 1
+warnings-as-errors: false
+include:
+  - zuul.d/**
+exclude:
+  - tests/**
+rules:
+  check-playbook-paths: error
+  check-duplicated-jobs: warning
+  check-inexistent-nodesets: warning
+  check-duplicate-semaphore: error
+```
+
+**Wrapped (`zuulcilint:` key):**
+```yaml
+zuulcilint:
+  version: 1
+  rules:
+    check-duplicated-jobs: error
+```
+
+Mixing both in the same file is rejected with an error.
+
+## Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `version` | integer | — | **Required.** Must be `1`. |
+| `warnings-as-errors` | boolean | `false` | Treat all warnings as errors. Equivalent to `--warnings-as-errors`. CLI flag takes precedence. |
+| `include` | list of globs | `[]` | Only lint files matching at least one pattern. Matched against repo-relative POSIX paths (e.g. `zuul.d/jobs.yaml`). |
+| `exclude` | list of globs | `[]` | Skip files matching any pattern. Applied after `include`. |
+| `rules` | mapping | see below | Per-rule severity overrides. |
+
+## Rule Severities
+
+Each rule accepts one of: `error`, `warning`, `disable`.
+
+| Rule | Default | Description |
+|------|---------|-------------|
+| `check-playbook-paths` | `disable` | Validate that playbook paths referenced in jobs exist on disk. Opt-in: also requires `--check-playbook-paths` CLI flag, or set to `error`/`warning` here to enable without the flag. |
+| `check-duplicated-jobs` | `warning` | Detect jobs defined more than once across the scanned files. |
+| `check-inexistent-nodesets` | `warning` | Detect jobs referencing nodesets that are not defined. |
+| `check-duplicate-semaphore` | `error` | Detect jobs that declare the same semaphore in both `semaphore` and `run`. |
+
+Setting a rule to `disable` skips it entirely — it produces no output and does not affect the exit code.
+
+Promoting a default-`warning` rule to `error` causes a non-zero exit when that rule finds issues.
+
+## CLI Flag Precedence
+
+| Scenario | Behaviour |
+|----------|-----------|
+| `--warnings-as-errors` CLI flag | Always wins; config `warnings-as-errors: true` is equivalent |
+| `--check-playbook-paths` CLI flag | Always runs the check at `error` severity, even if config says `disable` |
+| `--config <path>` | Used exclusively; home and repo-level configs are ignored |
+| `--ignore-warnings` | Suppresses warning output (unaffected by config) |
+
+## Examples
+
+### Promote all warnings to errors in CI
+```yaml
+version: 1
+warnings-as-errors: true
+```
+
+### Lint only files in `zuul.d/`, skip test fixtures
+```yaml
+version: 1
+include:
+  - zuul.d/**
+exclude:
+  - tests/**
+```
+
+### Enable playbook path checking via config (no CLI flag needed)
+```yaml
+version: 1
+rules:
+  check-playbook-paths: error
+```
+
+### Disable a noisy check during migration
+```yaml
+version: 1
+rules:
+  check-inexistent-nodesets: disable
+```

--- a/docs/zuulcilint.example.yaml
+++ b/docs/zuulcilint.example.yaml
@@ -1,0 +1,36 @@
+# Example zuulcilint configuration file.
+# Copy this to .zuulcilint.yaml at the root of your repository
+# and adjust as needed.
+# Full documentation: docs/configuration.md
+---
+version: 1
+
+# Treat warnings as errors (useful for strict CI enforcement).
+warnings-as-errors: false
+
+# Only lint files under these glob patterns
+# (repo-relative POSIX paths).
+# An empty list means "lint everything discovered".
+include: []
+
+# Skip files matching any of these patterns.
+# Useful for ignoring generated files or test fixtures.
+exclude: []
+
+rules:
+  # Validate that playbook paths referenced
+  # in jobs exist on disk.
+  # Set to "error" or "warning" to enable
+  # without the --check-playbook-paths flag.
+  check-playbook-paths: disable
+
+  # Detect jobs defined more than once across the scanned files.
+  check-duplicated-jobs: warning
+
+  # Detect jobs referencing nodesets that are
+  # not defined in the scanned files.
+  check-inexistent-nodesets: warning
+
+  # Detect jobs that declare the same
+  # semaphore in both semaphore and run.
+  check-duplicate-semaphore: error

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,373 @@
+"""Tests for zuulcilint configuration loading and CLI --config flag."""
+
+from __future__ import annotations
+
+import textwrap
+from collections import Counter
+
+import pytest
+
+from zuulcilint.config import DEFAULT_RULES, VALID_RULES, load_config
+from zuulcilint.__main__ import main
+
+
+# ---------------------------------------------------------------------------
+# load_config unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_config_no_files_returns_defaults(tmp_path, monkeypatch):
+    """With no config files present, defaults are returned."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config = load_config()
+    assert config["version"] == 1
+    assert config["rules"] == DEFAULT_RULES
+    assert config["include"] == []
+    assert config["exclude"] == []
+    assert config["warnings-as-errors"] is False
+
+
+def test_load_config_explicit_path(tmp_path):
+    """Explicit --config path is loaded and merged over defaults."""
+    cfg = tmp_path / "my.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            rules:
+              check-duplicate-semaphore: warning
+        """)
+    )
+    config = load_config(str(cfg))
+    assert config["rules"]["check-duplicate-semaphore"] == "warning"
+    # Other rules keep their defaults
+    assert config["rules"]["check-duplicated-jobs"] == DEFAULT_RULES["check-duplicated-jobs"]
+
+
+def test_load_config_missing_explicit_path_raises(tmp_path):
+    """FileNotFoundError is raised when the explicit path does not exist."""
+    with pytest.raises(FileNotFoundError, match="not found"):
+        load_config(str(tmp_path / "nonexistent.yaml"))
+
+
+def test_load_config_explicit_path_is_directory_raises(tmp_path):
+    """FileNotFoundError is raised when --config points to a directory."""
+    with pytest.raises(FileNotFoundError, match="directory"):
+        load_config(str(tmp_path))
+
+
+def test_load_config_rules_not_a_mapping_raises(tmp_path):
+    """ValueError is raised when 'rules' is not a mapping."""
+    cfg = tmp_path / "bad-rules.yaml"
+    cfg.write_text("version: 1\nrules: error\n")
+    with pytest.raises(ValueError, match="is not of type 'object'"):
+        load_config(str(cfg))
+
+
+def test_load_config_flat_format(tmp_path):
+    """Flat config format (no 'zuulcilint:' wrapper) is accepted."""
+    cfg = tmp_path / ".zuulcilint.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            warnings-as-errors: true
+            rules:
+              check-inexistent-nodesets: error
+        """)
+    )
+    config = load_config(str(cfg))
+    assert config["warnings-as-errors"] is True
+    assert config["rules"]["check-inexistent-nodesets"] == "error"
+
+
+def test_load_config_wrapped_format(tmp_path):
+    """Wrapped 'zuulcilint:' format is accepted."""
+    cfg = tmp_path / "wrapped.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            zuulcilint:
+              version: 1
+              rules:
+                check-duplicated-jobs: error
+        """)
+    )
+    config = load_config(str(cfg))
+    assert config["rules"]["check-duplicated-jobs"] == "error"
+
+
+def test_load_config_ambiguous_format_raises(tmp_path):
+    """A file mixing flat keys and the 'zuulcilint:' wrapper raises ValueError."""
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            zuulcilint:
+              rules:
+                check-duplicated-jobs: error
+        """)
+    )
+    with pytest.raises(ValueError, match="ambiguous"):
+        load_config(str(cfg))
+
+
+def test_load_config_missing_version_raises(tmp_path):
+    """A config file without 'version' raises ValueError."""
+    cfg = tmp_path / "no-ver.yaml"
+    cfg.write_text("rules:\n  check-duplicated-jobs: error\n")
+    with pytest.raises(ValueError, match="is a required property"):
+        load_config(str(cfg))
+
+
+def test_load_config_unsupported_version_raises(tmp_path):
+    """A config file with version != 1 raises ValueError."""
+    cfg = tmp_path / "v2.yaml"
+    cfg.write_text("version: 2\n")
+    with pytest.raises(ValueError, match="unsupported version"):
+        load_config(str(cfg))
+
+
+def test_load_config_unknown_rule_raises(tmp_path):
+    """A config file with an unknown rule name raises ValueError."""
+    cfg = tmp_path / "bad-rule.yaml"
+    cfg.write_text("version: 1\nrules:\n  check-made-up-rule: error\n")
+    with pytest.raises(ValueError, match="Additional properties are not allowed"):
+        load_config(str(cfg))
+
+
+def test_load_config_invalid_severity_raises(tmp_path):
+    """A config file with an invalid severity raises ValueError."""
+    cfg = tmp_path / "bad-sev.yaml"
+    cfg.write_text("version: 1\nrules:\n  check-duplicated-jobs: critical\n")
+    with pytest.raises(ValueError, match="is not valid under any"):
+        load_config(str(cfg))
+
+
+def test_load_config_unknown_top_level_key_raises(tmp_path):
+    """A config file with an unknown top-level key raises ValueError."""
+    cfg = tmp_path / "bad-key.yaml"
+    cfg.write_text("version: 1\nunknown-option: true\n")
+    with pytest.raises(ValueError, match="invalid config"):
+        load_config(str(cfg))
+
+
+def test_load_config_include_not_a_list_raises(tmp_path):
+    """A config file with 'include' as a string (not a list) raises ValueError."""
+    cfg = tmp_path / "bad-include.yaml"
+    cfg.write_text("version: 1\ninclude: '*.yaml'\n")
+    with pytest.raises(ValueError, match="invalid config"):
+        load_config(str(cfg))
+
+
+def test_load_config_exclude_not_a_list_raises(tmp_path):
+    """A config file with 'exclude' as a string (not a list) raises ValueError."""
+    cfg = tmp_path / "bad-exclude.yaml"
+    cfg.write_text("version: 1\nexclude: '*.yaml'\n")
+    with pytest.raises(ValueError, match="invalid config"):
+        load_config(str(cfg))
+
+
+def test_load_config_warnings_as_errors_not_bool_raises(tmp_path):
+    """A config file with 'warnings-as-errors' as a string raises ValueError."""
+    cfg = tmp_path / "bad-wae.yaml"
+    cfg.write_text("version: 1\nwarnings-as-errors: 'yes'\n")
+    with pytest.raises(ValueError, match="invalid config"):
+        load_config(str(cfg))
+
+
+def test_load_config_version_not_integer_raises(tmp_path):
+    """A config file with a string version raises ValueError."""
+    cfg = tmp_path / "str-ver.yaml"
+    cfg.write_text("version: '1'\n")
+    with pytest.raises(ValueError, match="invalid config"):
+        load_config(str(cfg))
+
+
+def test_load_config_disable_all_rules(tmp_path):
+    """All rules can be set to 'disable'."""
+    rules_block = "\n".join(f"  {r}: disable" for r in VALID_RULES)
+    cfg = tmp_path / "disable-all.yaml"
+    cfg.write_text(f"version: 1\nrules:\n{rules_block}\n")
+    config = load_config(str(cfg))
+    for rule in VALID_RULES:
+        assert config["rules"][rule] == "disable"
+
+
+def test_load_config_priority_explicit_beats_repo(tmp_path, monkeypatch):
+    """Explicit --config is used exclusively; repo-level config is ignored."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".zuulcilint.yaml").write_text(
+        "version: 1\nrules:\n  check-duplicated-jobs: error\n"
+    )
+    explicit = tmp_path / "explicit.yaml"
+    explicit.write_text(
+        "version: 1\nrules:\n  check-duplicated-jobs: disable\n"
+    )
+
+    monkeypatch.chdir(repo)
+    config = load_config(str(explicit))
+
+    # explicit wins exclusively — repo value must NOT bleed through
+    assert config["rules"]["check-duplicated-jobs"] == "disable"
+
+
+def test_load_config_priority_repo_beats_home(tmp_path, monkeypatch):
+    """Repo-level config is used exclusively; home-level config is ignored."""
+    home = tmp_path / "home"
+    home.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    (home / ".zuulcilint.yaml").write_text(
+        "version: 1\nrules:\n  check-duplicated-jobs: error\n"
+    )
+    (repo / ".zuulcilint.yaml").write_text(
+        "version: 1\nrules:\n  check-duplicated-jobs: disable\n"
+    )
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(repo)
+    config = load_config()
+
+    # repo-level wins — home value must NOT bleed through
+    assert config["rules"]["check-duplicated-jobs"] == "disable"
+
+
+def test_load_config_include_exclude(tmp_path):
+    """include/exclude glob lists are returned as-is."""
+    cfg = tmp_path / "filters.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            include:
+              - zuul.d/**
+            exclude:
+              - tests/**
+        """)
+    )
+    config = load_config(str(cfg))
+    assert config["include"] == ["zuul.d/**"]
+    assert config["exclude"] == ["tests/**"]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests via direct main() calls
+# ---------------------------------------------------------------------------
+
+
+def test_cli_config_invalid_path(tmp_path, capsys):
+    """--config with a non-existent path exits with an error message."""
+    missing = tmp_path / "nonexistent.yaml"
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--config", str(missing), "tests/zuul_data"])
+    assert exc_info.value.code != 0
+    assert "Config error" in capsys.readouterr().err
+
+
+def test_cli_config_disable_duplicated_jobs(tmp_path, capsys):
+    """check-duplicated-jobs: disable suppresses the duplicate-jobs warning."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("version: 1\nrules:\n  check-duplicated-jobs: disable\n")
+    with pytest.raises(SystemExit):
+        main(["--config", str(cfg), "tests/zuul_data"])
+    assert "duplicate jobs" not in capsys.readouterr().out.lower()
+
+
+def test_cli_config_promote_duplicated_jobs_to_error(tmp_path, capsys):
+    """check-duplicated-jobs: error causes a non-zero exit when duplicates exist."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("version: 1\nrules:\n  check-duplicated-jobs: error\n")
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--config", str(cfg), "tests/zuul_data"])
+    assert exc_info.value.code != 0
+
+
+def test_cli_config_warnings_as_errors_from_config(tmp_path, capsys):
+    """warnings-as-errors: true in config behaves like --warnings-as-errors flag."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("version: 1\nwarnings-as-errors: true\n")
+    with pytest.raises(SystemExit) as exc_config:
+        main(["--config", str(cfg), "tests/zuul_data"])
+    with pytest.raises(SystemExit) as exc_flag:
+        main(["--warnings-as-errors", "tests/zuul_data"])
+    assert exc_config.value.code == exc_flag.value.code
+
+
+def test_cli_no_config_preserves_existing_behavior(tmp_path, monkeypatch, capsys):
+    """Running without --config produces the same results as before this feature."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with pytest.raises(SystemExit) as exc_info:
+        main(["tests/zuul_data"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "Found 5 inexistent nodesets" in out
+    assert "Found 1 duplicate jobs" in out
+
+
+def test_example_config_is_valid(tmp_path):
+    """A default-equivalent config loads without errors and matches defaults."""
+    cfg = tmp_path / ".zuulcilint.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            warnings-as-errors: false
+            include: []
+            exclude: []
+            rules:
+              check-playbook-paths: disable
+              check-duplicated-jobs: warning
+              check-inexistent-nodesets: warning
+              check-duplicate-semaphore: error
+        """)
+    )
+    config = load_config(str(cfg))
+    assert config["version"] == 1
+    assert config["rules"] == DEFAULT_RULES
+    assert config["warnings-as-errors"] is False
+    assert config["include"] == []
+    assert config["exclude"] == []
+
+
+def test_example_config_produces_same_output_as_no_config(tmp_path, monkeypatch, capsys):
+    """Linting with a default-equivalent config gives identical results to linting without one."""
+    cfg = tmp_path / ".zuulcilint.yaml"
+    cfg.write_text(
+        textwrap.dedent("""\
+            version: 1
+            warnings-as-errors: false
+            include: []
+            exclude: []
+            rules:
+              check-playbook-paths: disable
+              check-duplicated-jobs: warning
+              check-inexistent-nodesets: warning
+              check-duplicate-semaphore: error
+        """)
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with pytest.raises(SystemExit) as exc_default:
+        main(["tests/zuul_data"])
+    out_default = capsys.readouterr().out
+    with pytest.raises(SystemExit) as exc_example:
+        main(["--config", str(cfg), "tests/zuul_data"])
+    out_example = capsys.readouterr().out
+    assert exc_default.value.code == exc_example.value.code
+    assert Counter(out_default.splitlines()) == Counter(out_example.splitlines())
+
+
+def test_cli_explicit_file_matching_exclude_prints_warning(tmp_path, capsys):
+    """Explicitly passing a file that matches an exclude pattern prints a warning to stdout."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("version: 1\nexclude:\n  - tests/zuul_data/*.yaml\n")
+    with pytest.raises(SystemExit):
+        main(["--config", str(cfg), "tests/zuul_data/jobs.yaml"])
+    assert "explicitly passed but matches an exclude pattern" in capsys.readouterr().out
+
+
+def test_cli_dir_matching_exclude_no_warning(tmp_path, capsys):
+    """Passing a directory whose contents are excluded does NOT print a per-file warning."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("version: 1\nexclude:\n  - tests/zuul_data/*.yaml\n")
+    with pytest.raises(SystemExit):
+        main(["--config", str(cfg), "tests/zuul_data"])
+    assert "explicitly passed but matches an exclude pattern" not in capsys.readouterr().out

--- a/zuulcilint/__main__.py
+++ b/zuulcilint/__main__.py
@@ -6,6 +6,7 @@ A linter for Zuul configuration files.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import importlib.metadata
 import pathlib
 import sys
@@ -16,6 +17,7 @@ from jsonschema import Draft201909Validator
 
 import zuulcilint.checker as zuul_checker
 import zuulcilint.utils as zuul_utils
+from zuulcilint.config import DEFAULT_RULES, load_config
 from zuulcilint.utils import MsgSeverity, ZuulObject
 
 # Register constructors for custom YAML tags
@@ -140,6 +142,36 @@ def get_all_zuul_yaml_files(files: list[str]) -> list[pathlib.Path]:
     return zuul_yaml_files
 
 
+def _apply_file_filters(
+    yaml_files_dict: dict,
+    include_patterns: list[str],
+    exclude_patterns: list[str],
+    root: pathlib.Path,
+) -> dict:
+    """Filter discovered YAML files by include/exclude glob patterns.
+
+    Patterns are matched against repo-relative POSIX paths (e.g. 'zuul.d/jobs.yaml').
+    If include_patterns is non-empty, a file must match at least one pattern to be kept.
+    Files matching any exclude pattern are always dropped.
+    """
+    if not include_patterns and not exclude_patterns:
+        return yaml_files_dict
+
+    def should_include(path: pathlib.Path) -> bool:
+        try:
+            rel = path.relative_to(root).as_posix()
+        except ValueError:
+            rel = str(path)
+
+        if include_patterns and not any(fnmatch.fnmatch(rel, pat) for pat in include_patterns):
+            return False
+        if exclude_patterns and any(fnmatch.fnmatch(rel, pat) for pat in exclude_patterns):
+            return False
+        return True
+
+    return {key: [p for p in paths if should_include(p)] for key, paths in yaml_files_dict.items()}
+
+
 def get_all_zuul_objects_by_type(
     zuul_yaml_files: list[pathlib.Path],
     zuul_obj: ZuulObject,
@@ -163,30 +195,37 @@ def get_all_zuul_objects_by_type(
 
 
 def print_warnings(
-    warnings: dict,
+    results: dict,
+    rule_severities: dict,
     severity: MsgSeverity = MsgSeverity.WARNING,
 ) -> None:
-    """Print warnings.
+    """Print findings that are routed to warning severity.
 
     Args:
     ----
-        warnings: A dictionary containing warnings.
-        severity: A MsgSeverity enum.
+        results: A flat dictionary of per-rule findings.
+        rule_severities: Per-rule severity mapping from the loaded config.
+        severity: Display severity (WARNING normally, ERROR when warnings-as-errors).
 
     Returns:
     -------
         None.
     """
-    n_bad_yaml = len(warnings["warnings"]["bad_yaml_files"])
-    n_duplicate_jobs = len(warnings["warnings"]["duplicated_jobs"])
-    n_nodeset = len(warnings["warnings"]["inexistent_nodesets"])
+    n_bad_yaml = len(results["bad_yaml_files"])
 
-    if n_bad_yaml == 0 and n_duplicate_jobs == 0 and n_nodeset == 0:
+    # Only include rule findings configured at "warning" severity.
+    n_duplicate_jobs = len(results["duplicated_jobs"]) if rule_severities.get("check-duplicated-jobs") == "warning" else 0
+    n_nodeset = len(results["inexistent_nodesets"]) if rule_severities.get("check-inexistent-nodesets") == "warning" else 0
+    n_duplicate_semaphores = len(results["duplicate_semaphores"]) if rule_severities.get("check-duplicate-semaphore") == "warning" else 0
+    n_playbook_paths = len(results["playbook_paths"]) if rule_severities.get("check-playbook-paths") == "warning" else 0
+
+    n_total = n_duplicate_jobs + n_nodeset + n_duplicate_semaphores + n_playbook_paths
+    if n_bad_yaml == 0 and n_total == 0:
         return
 
     if severity == MsgSeverity.WARNING:
         zuul_utils.print_bold("Warnings", MsgSeverity.WARNING)
-        print(f"Total {severity.value}s: {n_duplicate_jobs + n_nodeset}")
+        print(f"Total {severity.value}s: {n_total}")
 
     if n_bad_yaml:
         zuul_utils.print_bold(f"File extension {severity.value}s:", severity)
@@ -194,61 +233,101 @@ def print_warnings(
             f"Found {n_bad_yaml} files with 'yml' extension",
             None,
         )
-        for file_path in warnings["warnings"]["bad_yaml_files"]:
+        for file_path in results["bad_yaml_files"]:
             print(f"{file_path}")
 
     if n_duplicate_jobs:
         zuul_utils.print_bold(f"Duplicate job {severity.value}s:", severity)
         zuul_utils.print_bold(f"Found {n_duplicate_jobs} duplicate jobs", None)
-        for job in warnings["warnings"]["duplicated_jobs"]:
+        for job in results["duplicated_jobs"]:
             print(f"{job}")
 
     if n_nodeset:
         zuul_utils.print_bold(f"Inexistent nodeset {severity.value}s:", severity)
         zuul_utils.print_bold(f"Found {n_nodeset} inexistent nodesets", None)
-        for nodeset in warnings["warnings"]["inexistent_nodesets"]:
+        for nodeset in results["inexistent_nodesets"]:
             print(f"{nodeset}")
+
+    if n_duplicate_semaphores:
+        zuul_utils.print_bold(f"Duplicate semaphore {severity.value}s:", severity)
+        zuul_utils.print_bold(f"Found {n_duplicate_semaphores} duplicate semaphores", None)
+        for entry in results["duplicate_semaphores"]:
+            print(f"{entry}")
+
+    if n_playbook_paths:
+        zuul_utils.print_bold(f"Invalid playbook path {severity.value}s:", severity)
+        zuul_utils.print_bold(f"Found {n_playbook_paths} invalid playbook paths", None)
+        for entry in results["playbook_paths"]:
+            print(f"{entry}")
 
 
 def print_results(
     results: dict,
     warnings_as_errors,
     ignore_warnings,
+    *,
+    rule_severities: dict,
 ) -> None:
     """Print the linting results.
 
     Args:
     ----
-        results: A dictionary containing linting results.
+        results: A flat dictionary of per-rule findings.
         warnings_as_errors: A boolean indicating whether to handle warnings as errors.
         ignore_warnings: A boolean indicating whether to ignore warnings.
+        rule_severities: Per-rule severity mapping from the loaded config.
 
     Returns:
     -------
         None.
     """
-    duplicated_jobs = results["warnings"]["duplicated_jobs"]
-    inexistent_nodesets = results["warnings"]["inexistent_nodesets"]
-    bad_yaml_files = results["warnings"]["bad_yaml_files"]
-    total_semaphore_errors = results["errors"]["duplicated_semaphores"]
-    total_yaml_errors = results["errors"]["yaml"]
-    total_playbook_path_errors = results["errors"]["playbook_paths"]
-    total_warnings = len(bad_yaml_files) + len(duplicated_jobs) + len(inexistent_nodesets)
-    total_errs = total_yaml_errors + total_playbook_path_errors + total_semaphore_errors
-    extra_msg = ""
+    sev_dup_jobs   = rule_severities.get("check-duplicated-jobs",    DEFAULT_RULES["check-duplicated-jobs"])
+    sev_nodesets   = rule_severities.get("check-inexistent-nodesets", DEFAULT_RULES["check-inexistent-nodesets"])
+    sev_semaphores = rule_severities.get("check-duplicate-semaphore", DEFAULT_RULES["check-duplicate-semaphore"])
+    sev_playbooks  = rule_severities.get("check-playbook-paths",      DEFAULT_RULES["check-playbook-paths"])
 
-    # --warnings-as-errors flag has higher precedence than --ignore-warnings
+    n_yaml_errors = results["yaml_schema_errors"]
+    n_bad_yaml = len(results["bad_yaml_files"])
+    n_dup_jobs = len(results["duplicated_jobs"])
+    n_nodesets = len(results["inexistent_nodesets"])
+    n_semaphores = len(results["duplicate_semaphores"])
+    n_playbooks = len(results["playbook_paths"])
+
+    # Findings at "error" severity contribute to the error count.
+    total_errs = n_yaml_errors
+    if sev_dup_jobs == "error":
+        total_errs += n_dup_jobs
+    if sev_nodesets == "error":
+        total_errs += n_nodesets
+    if sev_semaphores == "error":
+        total_errs += n_semaphores
+    if sev_playbooks == "error":
+        total_errs += n_playbooks
+
+    # Findings at "warning" severity (bad_yaml_files is always a warning).
+    total_warnings = n_bad_yaml
+    if sev_dup_jobs == "warning":
+        total_warnings += n_dup_jobs
+    if sev_nodesets == "warning":
+        total_warnings += n_nodesets
+    if sev_semaphores == "warning":
+        total_warnings += n_semaphores
+    if sev_playbooks == "warning":
+        total_warnings += n_playbooks
+
+    extra_msg = ""
+    # --warnings-as-errors flag has higher precedence than --ignore-warnings.
     if warnings_as_errors:
         total_errs += total_warnings
-        if bad_yaml_files:
-            extra_msg += f"\nFile extension errors: {len(bad_yaml_files)}"
-        if duplicated_jobs:
-            extra_msg += f"\nDuplicated jobs errors: {len(duplicated_jobs)}"
-        if inexistent_nodesets:
-            extra_msg += f"\nInexistent nodesets errors: {len(inexistent_nodesets)}"
-        print_warnings(warnings=results, severity=MsgSeverity.ERROR)
+        if n_bad_yaml:
+            extra_msg += f"\nFile extension errors: {n_bad_yaml}"
+        if sev_dup_jobs == "warning" and n_dup_jobs:
+            extra_msg += f"\nDuplicated jobs errors: {n_dup_jobs}"
+        if sev_nodesets == "warning" and n_nodesets:
+            extra_msg += f"\nInexistent nodesets errors: {n_nodesets}"
+        print_warnings(results=results, rule_severities=rule_severities, severity=MsgSeverity.ERROR)
     elif not ignore_warnings:
-        print_warnings(warnings=results)
+        print_warnings(results=results, rule_severities=rule_severities)
 
     if total_errs == 0:
         zuul_utils.print_bold("Passed", MsgSeverity.SUCCESS)
@@ -257,19 +336,32 @@ def print_results(
     zuul_utils.print_bold("Failed", MsgSeverity.ERROR)
     err_msg = f"Total errors: {total_errs}\n"
 
-    if total_semaphore_errors:
-        err_msg += f"Duplicated semaphores: {total_semaphore_errors}"
-    if total_playbook_path_errors:
-        err_msg += f"\nPlaybook path errors: {total_playbook_path_errors}"
-    if total_yaml_errors:
-        err_msg += f"\nYAML validation errors: {total_yaml_errors}"
+    if sev_semaphores == "error" and n_semaphores:
+        err_msg += f"Duplicated semaphores: {n_semaphores}"
+    if sev_playbooks == "error" and n_playbooks:
+        err_msg += f"\nPlaybook path errors: {n_playbooks}"
+    if n_yaml_errors:
+        err_msg += f"\nYAML validation errors: {n_yaml_errors}"
+
+    # Findings from default-warning rules promoted to error via config.
+    n_promoted = 0
+    if sev_dup_jobs == "error":
+        n_promoted += n_dup_jobs
+    if sev_nodesets == "error":
+        n_promoted += n_nodesets
+    if n_promoted:
+        err_msg += f"\nPromoted warning errors: {n_promoted}"
 
     zuul_utils.print_bold(f"{err_msg + extra_msg}", MsgSeverity.ERROR)
     sys.exit(1)
 
 
-def main():
+def main(argv: list[str] | None = None):
     """Parse command-line arguments and run the Zuul linter on the specified file(s).
+
+    Args:
+    ----
+        argv: Optional list of arguments. Defaults to sys.argv[1:] when None.
 
     Returns
     -------
@@ -306,83 +398,144 @@ def main():
         help="handle warnings as errors",
         action="store_true",
     )
+    parser.add_argument(
+        "--config",
+        help="path to a zuulcilint config file (overrides auto-discovered configs)",
+        default=None,
+        metavar="PATH",
+    )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(args.config)
+    except (FileNotFoundError, ValueError) as exc:
+        zuul_utils.print_bold(f"Config error: {exc}", MsgSeverity.ERROR)
+        sys.exit(1)
+
+    rule_severities: dict = config["rules"]
+    # CLI --warnings-as-errors takes precedence; config value is the fallback.
+    effective_wae: bool = args.warnings_as_errors or config.get("warnings-as-errors", False)
+
     schema = zuul_utils.get_zuul_schema(schema_file=args.schema)
     all_zuul_yaml_files = get_all_zuul_yaml_files(args.file)
-    zuul_good_yaml = all_zuul_yaml_files["good_yaml"]
-    zuul_bad_yaml = all_zuul_yaml_files["bad_yaml"]
 
-    # Initialize results dictionary
+    # Apply include/exclude glob filters from config (repo-relative POSIX paths).
+    include_pats: list[str] = config.get("include", [])
+    exclude_pats: list[str] = config.get("exclude", [])
+    if include_pats or exclude_pats:
+        # Warn when the user explicitly passed a file (not a directory) that
+        # matches an exclude pattern — silently dropping it would be misleading.
+        if exclude_pats:
+            cwd = pathlib.Path.cwd()
+            for raw in args.file:
+                p = pathlib.Path(raw)
+                if p.is_file():
+                    try:
+                        rel = p.relative_to(cwd).as_posix()
+                    except ValueError:
+                        rel = str(p)
+                    if any(fnmatch.fnmatch(rel, pat) for pat in exclude_pats):
+                        zuul_utils.print_bold(
+                            f"warning: {rel} explicitly passed but matches an "
+                            f"exclude pattern — skipping",
+                            MsgSeverity.WARNING,
+                        )
+
+        all_zuul_yaml_files = _apply_file_filters(
+            all_zuul_yaml_files,
+            include_pats,
+            exclude_pats,
+            pathlib.Path.cwd(),
+        )
+
+    zuul_good_yaml = all_zuul_yaml_files.get("good_yaml", [])
+    zuul_bad_yaml = all_zuul_yaml_files.get("bad_yaml", [])
+
+    # Flat results dict — findings stored per-rule, severity applied at display time.
     results = {
-        "errors": {"duplicated_semaphores": 0, "playbook_paths": 0, "yaml": 0 },
-        "warnings": {
-            "duplicated_jobs": [],
-            "inexistent_nodesets": [],
-            "bad_yaml_files": zuul_bad_yaml,
-        },
+        "yaml_schema_errors": 0,
+        "bad_yaml_files": zuul_bad_yaml,
+        "duplicated_jobs": [],
+        "inexistent_nodesets": [],
+        "duplicate_semaphores": [],
+        "playbook_paths": [],
     }
 
     # Lint all Zuul YAML files
-    results["errors"]["yaml"] = lint_all_yaml_files(zuul_good_yaml, schema)
+    results["yaml_schema_errors"] = lint_all_yaml_files(zuul_good_yaml, schema)
 
-    # Check playbook paths if specified
-    if args.check_playbook_paths:
+    # Check playbook paths.
+    # Runs if the CLI flag is given OR if config explicitly enables it (non-disable severity).
+    # CLI flag always wins: even if config says "disable", the flag forces the check to run
+    # at "error" severity.
+    sev_playbook = rule_severities.get("check-playbook-paths", DEFAULT_RULES["check-playbook-paths"])
+    run_playbook_check = args.check_playbook_paths or sev_playbook != "disable"
+    # When the CLI flag forces the check but config says "disable", treat as "error".
+    if args.check_playbook_paths and sev_playbook == "disable":
+        rule_severities = dict(rule_severities)
+        rule_severities["check-playbook-paths"] = "error"
+
+    if run_playbook_check:
         zuul_utils.print_bold("Checking playbook paths", MsgSeverity.INFO)
         invalid_playbook_paths = lint_playbook_paths(zuul_good_yaml)
         if invalid_playbook_paths:
-            results["errors"]["playbook_paths"] = len(invalid_playbook_paths)
+            results["playbook_paths"] = [f"invalid playbook path: {p}" for p in invalid_playbook_paths]
             zuul_utils.print_bold("Invalid playbook paths:", MsgSeverity.ERROR)
             for path in invalid_playbook_paths:
                 print(f"{path}")
         else:
             print("No invalid playbook paths")
 
-    # Check duplicated jobs
-    zuul_utils.print_bold("Checking for duplicate jobs", MsgSeverity.INFO)
-    jobs_dict = {}
-    for yaml_file in zuul_good_yaml:
-        jobs_dict[yaml_file] = get_all_zuul_objects_by_type([yaml_file], ZuulObject.JOB)
+    # Check duplicated jobs (skip if disabled in config)
+    if rule_severities.get("check-duplicated-jobs") != "disable":
+        zuul_utils.print_bold("Checking for duplicate jobs", MsgSeverity.INFO)
+        jobs_dict = {}
+        for yaml_file in zuul_good_yaml:
+            jobs_dict[yaml_file] = get_all_zuul_objects_by_type([yaml_file], ZuulObject.JOB)
 
-    duplicated_jobs = zuul_checker.check_duplicated_jobs(jobs_dict)
+        duplicated_jobs = zuul_checker.check_duplicated_jobs(jobs_dict)
 
-    if duplicated_jobs:
-        for job in duplicated_jobs:
-            print(f"{job}")
-    else:
-        print("No duplicate jobs found")
-    results["warnings"]["duplicated_jobs"] = duplicated_jobs
+        if duplicated_jobs:
+            for job in duplicated_jobs:
+                print(f"{job}")
+        else:
+            print("No duplicate jobs found")
+        results["duplicated_jobs"] = duplicated_jobs
 
-    # Check for inexistent nodesets
-    zuul_utils.print_bold("Checking for inexistent nodesets", MsgSeverity.INFO)
-    inexistent_nodesets = zuul_checker.check_inexistent_nodesets(
-        get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.NODESET),
-        get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.JOB),
-    )
-    if inexistent_nodesets:
-        for nodeset in inexistent_nodesets:
-            print(f"{nodeset}")
-    else:
-        print("No inexistent nodesets found")
-    results["warnings"]["inexistent_nodesets"] = inexistent_nodesets
+    # Check for inexistent nodesets (skip if disabled in config)
+    if rule_severities.get("check-inexistent-nodesets") != "disable":
+        zuul_utils.print_bold("Checking for inexistent nodesets", MsgSeverity.INFO)
+        inexistent_nodesets = zuul_checker.check_inexistent_nodesets(
+            get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.NODESET),
+            get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.JOB),
+        )
+        if inexistent_nodesets:
+            for nodeset in inexistent_nodesets:
+                print(f"{nodeset}")
+        else:
+            print("No inexistent nodesets found")
+        results["inexistent_nodesets"] = inexistent_nodesets
 
-    # Check for duplicate semaphore in job and job.run
-    zuul_utils.print_bold("Checking for duplicate semaphore", MsgSeverity.INFO)
-    duplicate_semaphore = zuul_checker.check_duplicate_semaphore(
-        get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.JOB),
-    )
-    if duplicate_semaphore:
-        for semaphore in duplicate_semaphore:
-            print(f"{semaphore}")
-    else:
-        print("No duplicate semaphore found")
-    results["errors"]["duplicated_semaphores"] = len(duplicate_semaphore)
+    # Check for duplicate semaphore in job and job.run (skip if disabled in config)
+    if rule_severities.get("check-duplicate-semaphore") != "disable":
+        zuul_utils.print_bold("Checking for duplicate semaphore", MsgSeverity.INFO)
+        duplicate_semaphore = zuul_checker.check_duplicate_semaphore(
+            get_all_zuul_objects_by_type(zuul_good_yaml, ZuulObject.JOB),
+        )
+        if duplicate_semaphore:
+            for semaphore in duplicate_semaphore:
+                print(f"{semaphore}")
+        else:
+            print("No duplicate semaphore found")
+        results["duplicate_semaphores"] = list(duplicate_semaphore)
 
     # Print results
     print_results(
         results,
-        args.warnings_as_errors,
+        effective_wae,
         args.ignore_warnings,
+        rule_severities=rule_severities,
     )
 
 

--- a/zuulcilint/config-schema.json
+++ b/zuulcilint/config-schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "zuulcilint configuration file schema",
+  "description": "Schema for .zuulcilint.yaml configuration files.",
+  "type": "object",
+  "required": ["version"],
+  "additionalProperties": false,
+  "definitions": {
+    "rule-severity": {
+      "description": "Severity for a single rule — either a plain string or a dict with a 'level' key.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["error", "warning", "disable"]
+        },
+        {
+          "type": "object",
+          "required": ["level"],
+          "additionalProperties": false,
+          "properties": {
+            "level": {
+              "type": "string",
+              "enum": ["error", "warning", "disable"]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Config file format version. Must be 1."
+    },
+    "warnings-as-errors": {
+      "type": "boolean",
+      "description": "Treat all warnings as errors."
+    },
+    "include": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Only lint files matching at least one glob pattern."
+    },
+    "exclude": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Skip files matching any glob pattern."
+    },
+    "rules": {
+      "type": "object",
+      "description": "Per-rule severity overrides.",
+      "additionalProperties": false,
+      "properties": {
+        "check-duplicated-jobs":     {"$ref": "#/definitions/rule-severity"},
+        "check-inexistent-nodesets": {"$ref": "#/definitions/rule-severity"},
+        "check-duplicate-semaphore": {"$ref": "#/definitions/rule-severity"},
+        "check-playbook-paths":      {"$ref": "#/definitions/rule-severity"}
+      }
+    }
+  }
+}

--- a/zuulcilint/config.py
+++ b/zuulcilint/config.py
@@ -1,0 +1,187 @@
+"""Configuration file loader for zuulcilint."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import yaml
+from jsonschema import Draft201909Validator
+
+_CONFIG_SCHEMA_PATH = pathlib.Path(__file__).parent / "config-schema.json"
+_CONFIG_SCHEMA: dict = json.loads(_CONFIG_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+# Flat keys that are valid at the root of a config file (also used to detect
+# ambiguous configs that mix a 'zuulcilint:' wrapper with flat-format keys).
+_KNOWN_FLAT_KEYS: frozenset[str] = frozenset(
+    {"version", "include", "exclude", "warnings-as-errors", "rules", "select", "ignore"}
+)
+
+VALID_RULES = frozenset(
+    {
+        "check-playbook-paths",
+        "check-duplicated-jobs",
+        "check-inexistent-nodesets",
+        "check-duplicate-semaphore",
+    }
+)
+
+VALID_SEVERITIES = frozenset({"error", "warning", "disable"})
+
+# Default severities reproduce current CLI-only behaviour exactly.
+# check-playbook-paths defaults to "disable" because it is opt-in: it only runs
+# when the --check-playbook-paths CLI flag is given, or when a config file
+# explicitly sets its severity to "error" or "warning".
+DEFAULT_RULES: dict[str, str] = {
+    "check-playbook-paths": "disable",
+    "check-duplicated-jobs": "warning",
+    "check-inexistent-nodesets": "warning",
+    "check-duplicate-semaphore": "error",
+}
+
+
+def _default_config() -> dict:
+    return {
+        "version": 1,
+        "include": [],
+        "exclude": [],
+        "warnings-as-errors": False,
+        "rules": DEFAULT_RULES.copy(),
+    }
+
+
+def _resolve_severity(value: str | dict) -> str:
+    """Normalise rule severity from either 'error' or {'level': 'error'} form."""
+    if isinstance(value, dict):
+        value = value.get("level", "")
+    return value
+
+
+def _load_and_validate(path: pathlib.Path) -> dict:
+    """Load and validate a single config file, returning the parsed dict."""
+    try:
+        with pathlib.Path.open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path}: invalid YAML — {exc}") from exc
+
+    if raw is None:
+        raw = {}
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: config root must be a mapping, got {type(raw).__name__}")
+
+    # Support optional top-level 'zuulcilint:' wrapper key.
+    # Reject ambiguous files that mix both forms.
+    has_wrapper = "zuulcilint" in raw
+    flat_keys = set(raw) - {"zuulcilint"}
+    if has_wrapper and flat_keys & _KNOWN_FLAT_KEYS:
+        raise ValueError(
+            f"{path}: ambiguous config — contains both a 'zuulcilint:' wrapper key "
+            f"and flat keys ({flat_keys & _KNOWN_FLAT_KEYS})"
+        )
+    if has_wrapper:
+        raw = raw["zuulcilint"] or {}
+
+    # Validate structure and types against the JSON schema.
+    validator = Draft201909Validator(_CONFIG_SCHEMA)
+    schema_errors = sorted(validator.iter_errors(raw), key=lambda e: list(e.path))
+    if schema_errors:
+        messages = "; ".join(e.message for e in schema_errors)
+        raise ValueError(f"{path}: invalid config — {messages}")
+
+    # Semantic validation: version value.
+    # Rule names and severity values are validated by the JSON schema above.
+    if raw.get("version") != 1:
+        raise ValueError(
+            f"{path}: unsupported version {raw.get('version')!r} — only version 1 is supported"
+        )
+
+    return raw
+
+
+def _merge(base: dict, override: dict) -> None:
+    """Merge *override* into *base* in-place.
+
+    Applies the single loaded config file on top of the built-in defaults so
+    that partial config files work correctly (unspecified keys keep defaults).
+    Rule entries are merged individually; all other keys are replaced outright.
+    """
+    for key, value in override.items():
+        if key == "rules":
+            for rule, sev in value.items():
+                base["rules"][rule] = _resolve_severity(sev)
+        else:
+            base[key] = value
+
+
+def _resolve_config_path(
+    config_path: str | None,
+) -> tuple[pathlib.Path | None, str]:
+    """Return ``(path, source_description)`` for the highest-priority config.
+
+    Resolution order (highest priority first):
+      1. Explicit ``--config`` path.
+      2. ``.zuulcilint.yaml`` in the current working directory (repo-level).
+      3. ``.zuulcilint.yaml`` in the user's home directory (home-level).
+
+    Returns ``(None, "")`` when no config file is found and no explicit path
+    was supplied.
+    """
+    if config_path is not None:
+        path = pathlib.Path(config_path)
+        return path, f"explicit (--config {path})"
+
+    repo_config = pathlib.Path.cwd() / ".zuulcilint.yaml"
+    if repo_config.is_file():
+        return repo_config, "repo (./.zuulcilint.yaml)"
+
+    home_config = pathlib.Path.home() / ".zuulcilint.yaml"
+    if home_config.is_file():
+        return home_config, "home (~/.zuulcilint.yaml)"
+
+    return None, ""
+
+
+def load_config(config_path: str | None = None) -> dict:
+    """Resolve zuulcilint configuration using a strict priority order.
+
+    Config sources are mutually exclusive — only the highest-priority source
+    found is used.  Resolution order (later/higher overrides earlier/lower):
+
+      1. ~/.zuulcilint.yaml           (user home — lowest priority)
+      2. <repo-root>/.zuulcilint.yaml (repo-level)
+      3. path passed via --config     (explicit CLI argument — highest priority)
+
+    If no config files are found and no explicit path is given, returns defaults
+    that reproduce the current CLI-only behaviour exactly.
+
+    Args:
+    ----
+        config_path: Optional path supplied via --config CLI argument.
+
+    Returns:
+    -------
+        Configuration dictionary (merged over built-in defaults).
+
+    Raises:
+    ------
+        FileNotFoundError: If an explicit --config path does not exist or is a directory.
+        ValueError: If the config file is structurally invalid.
+    """
+    path, source = _resolve_config_path(config_path)
+
+    if path is None:
+        print("[zuulcilint] config: no config file found — using built-in defaults", file=sys.stderr)
+        return _default_config()
+
+    print(f"[zuulcilint] config: loading {source} → {path}", file=sys.stderr)
+    try:
+        merged = _default_config()
+        _merge(merged, _load_and_validate(path))
+        return merged
+    except IsADirectoryError as exc:
+        raise FileNotFoundError(f"Config path is a directory, not a file: {path}") from exc
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Config file not found: {path}") from None


### PR DESCRIPTION
Add a --config CLI flag and a new config.py module that enables users to
control zuulcilint behaviour via a YAML configuration file without having
to rely solely on CLI flags.

## Config resolution order (higher priority first)

1. `--config <path>` (explicit path — highest priority)
2. `<cwd>/.zuulcilint.yaml`
3. `~/.zuulcilint.yaml`

## Key design decisions

- **Per-rule severity**: each of the four checks can be set to `"error"`,
  `"warning"`, or `"disable"`. Disabled checks are skipped entirely before
  they run, not filtered after the fact.

- **check-playbook-paths** default is `"disable"` to preserve the existing
  opt-in behaviour. It runs when `--check-playbook-paths` is given OR when
  a config file explicitly sets it to `"error"` or `"warning"`. The CLI flag
  always wins over a config `"disable"` entry.

- **warnings-as-errors** can be set in config as well as via CLI flag.
  The two are OR-ed: either source enables it.

- **include/exclude** glob lists filter discovered YAML files by repo-relative
  POSIX path before any check runs. Explicitly passed files that match an
  exclude pattern produce a warning.

- **Flat results dict**: findings are stored per-rule with no pre-sorted
  errors/warnings grouping. Severity routing happens at display time in
  `print_results`/`print_warnings` via `rule_severities`.

- **Config validation via jsonschema**: `.zuulcilint.yaml` is validated
  with `Draft201909Validator` (same validator used for Zuul files) using a
  dedicated `config-schema.json`. The schema enforces structural/type
  constraints and validates rule names and severity values via a reusable
  `rule-severity` definition using `oneOf` (plain string enum OR
  `{level: string}` dict form). The manual rule name/severity loop is removed
  — the schema covers it.

- **Config loading de-duplicated**: `_resolve_config_path()` selects the
  highest-priority source; `load_config()` loads and merges exactly once.
  EAFP (try/except) used instead of LBYL for file access.

- **`DEFAULT_RULES`** constants used for all severity fallbacks in
  `print_results` and `main()` — no hardcoded strings.

- **`main(argv)`** accepts an optional argv list so CLI tests can call it
  directly instead of spawning subprocesses.

- **Both flat and `zuulcilint:`-wrapped** config formats are supported.
  Files mixing both are rejected with a clear error message.

## Tests

Adds 30 tests in `tests/test_config.py` covering config loading, validation
errors, merge order, CLI integration, and schema-validated error paths.
CLI tests use `main()` + `capsys` + `pytest.raises(SystemExit)` directly
instead of subprocess — faster and venv-stable. All 30 tests pass.

Issue: #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional YAML configuration files (`.zuulcilint.yaml`) enabling customization of rule severity levels (`error`, `warning`, `disable`).
  * Added `--config` command-line flag to specify explicit configuration file paths.
  * Added `include` and `exclude` glob patterns for filtering files during linting.
  * Added `warnings-as-errors` configuration option to treat warnings as errors.

* **Documentation**
  * Added comprehensive configuration documentation and example configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->